### PR TITLE
Fixes a path and typo

### DIFF
--- a/tasks/system/configure.yml
+++ b/tasks/system/configure.yml
@@ -6,7 +6,7 @@
   sudo: true
 
 - name: set gemrc
-  copy: src=../../files/gemrc dest=etc/gemrc
+  copy: src=../../files/gemrc dest=/etc/gemrc
   sudo: true
 
 - name: set vars

--- a/tasks/system/configure.yml
+++ b/tasks/system/configure.yml
@@ -10,5 +10,5 @@
   sudo: true
 
 - name: set vars
-  copy: src=../../files/svars dest={{ rbenv_root }}/vars
+  copy: src=../../files/vars dest={{ rbenv_root }}/vars
   sudo: true


### PR DESCRIPTION
Fixes an absolute path for the gemrc file destination and corrects what I believe is a typo in the source path for the vars file.